### PR TITLE
Fix bugs with directories of image sequences

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -36,7 +36,7 @@ set_source_files_properties(
 # Setup Info.plist
 set(MACOSX_BUNDLE_ICON_FILE ${icon_file})
 string(TIMESTAMP year "%Y")
-set(copyright "Copyright ${year} C. Seth Parker")
+set(copyright "${year} C. Seth Parker")
 string(CONCAT info_string
     ffdropenc${CMAKE_BUILD_TYPE}
     " Version ${PROJECT_VERSION}"

--- a/apps/src/EncodingQueue.cpp
+++ b/apps/src/EncodingQueue.cpp
@@ -68,7 +68,9 @@ void EncodingQueue::insert(std::vector<fs::path> files, const EncodeSettings& s)
     }
 
     // Sort queue by name and remove duplicates
-    std::sort(tempQueue.begin(), tempQueue.end());
+    std::sort(
+        tempQueue.begin(), tempQueue.end(),
+        [](const auto& l, const auto& r) { return *l < *r; });
     auto last = std::unique(
         tempQueue.begin(), tempQueue.end(),
         [](const auto& l, const auto& r) { return *l == *r; });

--- a/apps/src/EncodingQueue.cpp
+++ b/apps/src/EncodingQueue.cpp
@@ -75,6 +75,7 @@ void EncodingQueue::insert(std::vector<fs::path> files, const EncodeSettings& s)
         tempQueue.begin(), tempQueue.end(),
         [](const auto& l, const auto& r) { return *l == *r; });
     tempQueue.erase(last, tempQueue.end());
+    qDebug() << "Adding" << tempQueue.size() << "items to queue.";
 
     // insert items into analysis queue
     queue_.insert(queue_.end(), tempQueue.begin(), tempQueue.end());

--- a/libdropenc/include/ffdropenc/QueueItem.hpp
+++ b/libdropenc/include/ffdropenc/QueueItem.hpp
@@ -71,7 +71,9 @@ private:
     // image sequence
     static Type determine_type_(const std::filesystem::path& p);
     void convert_to_seq_();
-    size_t startingIndex_{0};
+    std::string nameStem_;
+    std::string seqNumStr_;
+    size_t determine_starting_index_() const;
 
     // encoding parameters
     Preset::Pointer preset_;

--- a/libdropenc/src/Preset.cpp
+++ b/libdropenc/src/Preset.cpp
@@ -87,14 +87,12 @@ QStringList Preset::getSettings(size_t index)
 
         // Handle audio streams
         else if (type == "audio") {
-            std::cout << s << std::endl;
             // Add the codec
             auto codec = s["codec"].get<std::string>();
             if(codec == "aac") {
                 // TODO: Replace with user-selected library
             }
             settings << "-c:a" << QString::fromStdString(codec);
-            std::cout << codec << " ";
 
             // Skip the rest of this loop if we're copying the input stream
             if (codec == "copy") {
@@ -104,13 +102,11 @@ QStringList Preset::getSettings(size_t index)
             // Append the output bitrate if we need it
             if (s.contains("bitrate")) {
                 auto bitrate = s["bitrate"].get<std::string>();
-                std::cout << bitrate << " ";
                 settings << "-b:a" << QString::fromStdString(bitrate);
             }
 
             if(s.contains("quality")) {
                 auto quality = s["quality"].get<std::string>();
-                std::cout << quality << " ";
                 settings << "-q:a" << QString::fromStdString(quality);
             }
         }

--- a/libdropenc/src/QueueItem.cpp
+++ b/libdropenc/src/QueueItem.cpp
@@ -79,25 +79,40 @@ void QueueItem::convert_to_seq_()
     // TODO: This only works if numerical pattern is at end of filename
     auto stem = inputPath_.stem().string();
     auto last_letter_pos = stem.find_last_not_of("0123456789");
-    auto fileName = stem.substr(0, last_letter_pos + 1);
-    auto seqNumber = stem.substr(last_letter_pos + 1);
+    nameStem_ = stem.substr(0, last_letter_pos + 1);
+    seqNumStr_ = stem.substr(last_letter_pos + 1);
 
     // Set the output filename
-    outputFileName_ = (fileName.empty())
+    outputFileName_ = (nameStem_.empty())
                           ? inputPath_.parent_path().stem().string()
-                          : fileName;
+                          : nameStem_;
+
+    // Convert seqNumber to the %nd format
+    auto seqNumber = std::to_string(seqNumStr_.length());
+    if (seqNumber.length() < 2) {
+        seqNumber.insert(0, "0");
+    }
+    seqNumber = "%" + seqNumber + "d";
+
+    // Final file name
+    auto completeStem = nameStem_ + seqNumber + inputPath_.extension().string();
+    inputPath_ = inputPath_.parent_path() / completeStem;
+}
+
+size_t QueueItem::determine_starting_index_() const
+{
+    // TODO: This only works if numerical pattern is at end of filename
 
     // Get list of all paths matching prefix in parent path
-    std::regex prefix{fileName + "([0-9]+)"};
+    std::regex prefix{nameStem_ + "([0-9]+)"};
     std::smatch match;
-    startingIndex_ = std::stoull(seqNumber);
+    size_t startIdx = std::stoull(seqNumStr_);
     for (const auto& it : fs::directory_iterator(inputPath_.parent_path())) {
         // Skip entries that aren't files
         if (not it.is_regular_file()) {
             continue;
         }
 
-        //
         auto fn = fs::path(it).stem().string();
         if (std::regex_match(fn, match, prefix)) {
             if (match.size() != 2) {
@@ -105,20 +120,10 @@ void QueueItem::convert_to_seq_()
             }
             // Get minimum and maximum sequence number from list
             size_t idx{std::stoull(match[1])};
-            startingIndex_ = std::min(startingIndex_, idx);
+            startIdx = std::min(startIdx, idx);
         }
     }
-
-    // Convert seqNumber to the %nd format
-    seqNumber = std::to_string(seqNumber.length());
-    if (seqNumber.length() < 2) {
-        seqNumber.insert(0, "0");
-    }
-    seqNumber = "%" + seqNumber + "d";
-
-    // Final file name
-    fileName += seqNumber + inputPath_.extension().string();
-    inputPath_ = inputPath_.parent_path() / fileName;
+    return startIdx;
 }
 
 // Construct the transcoding command
@@ -129,7 +134,7 @@ QStringList QueueItem::encodeArguments() const
     // Settings for img sequences
     if (type_ == Type::Sequence) {
         args << "-framerate" << inputFPS_;
-        args << "-start_number" << QString::number(startingIndex_);
+        args << "-start_number" << QString::number(determine_starting_index_());
     }
 
     // The input file

--- a/libdropenc/src/QueueItem.cpp
+++ b/libdropenc/src/QueueItem.cpp
@@ -55,15 +55,12 @@ QueueItem::Pointer QueueItem::New(
 // Operators
 bool QueueItem::operator<(const QueueItem& file) const
 {
-    if (inputPath_ == file.inputPath_ && type_ == file.type_)
-        return (startingIndex_ < file.startingIndex_);
-    else
-        return (inputPath_ < file.inputPath_);
+    return inputPath_ < file.inputPath_;
 }
 
 bool QueueItem::operator==(const QueueItem& file) const
 {
-    return (inputPath_ == file.inputPath_);
+    return inputPath_ == file.inputPath_;
 }
 
 // Construct the full output path from all of its requisite parts
@@ -123,8 +120,6 @@ void QueueItem::convert_to_seq_()
     fileName += seqNumber + inputPath_.extension().string();
     inputPath_ = inputPath_.parent_path() / fileName;
 }
-
-// Analyze
 
 // Construct the transcoding command
 QStringList QueueItem::encodeArguments() const


### PR DESCRIPTION
This fixes #31, where image sequences were getting added to the queue multiple times. This was caused by `std::sort` of QueueItem pointers, rather than sorting the items themselves.

This also only calculates image sequence starting indices when they're actually needed. This significantly reduces queue startup time when dropping directories containing image sequences.