### PR TITLE
Improve image sequence parsing

### DIFF
--- a/apps/src/EncodingQueue.cpp
+++ b/apps/src/EncodingQueue.cpp
@@ -70,8 +70,8 @@ void EncodingQueue::insert(std::vector<fs::path> files, const EncodeSettings& s)
     for (const auto& f : files) {
         try {
             tempQueue.emplace_back(QueueItem::New(f, s));
-        } catch (const std::runtime_error& e) {
-            qDebug() << e.what() << ":" << f.c_str();
+        } catch (const std::exception& e) {
+            qDebug() << "QueueItem error ::" << f.c_str() << "::" << e.what();
         }
     }
 

--- a/cmake/FindDeployQt5.cmake
+++ b/cmake/FindDeployQt5.cmake
@@ -16,7 +16,6 @@ function(qt5_deploy_bundle TARGET)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
         set(DeployFlags -no-strip)
     endif()
-    message("Deploy flags: ${DeployFlags}")
     add_custom_command(
         TARGET ${TARGET} POST_BUILD
         COMMAND "${DeployQt5_EXECUTABLE}" "$<TARGET_BUNDLE_DIR:${TARGET}>" "${DeployFlags}"

--- a/libdropenc/include/ffdropenc/QueueItem.hpp
+++ b/libdropenc/include/ffdropenc/QueueItem.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <exception>
 #include <filesystem>
 #include <iostream>
 
@@ -12,6 +13,20 @@
 
 namespace ffdropenc
 {
+
+class QueueItemException : public std::exception
+{
+public:
+    explicit QueueItemException(const char* msg) : msg_(msg) {}
+    explicit QueueItemException(std::string msg) : msg_(std::move(msg)) {}
+    [[nodiscard]] const char* what() const noexcept override
+    {
+        return msg_.c_str();
+    }
+
+protected:
+    std::string msg_;
+};
 
 class QueueItem
 {
@@ -71,8 +86,9 @@ private:
     // image sequence
     static Type determine_type_(const std::filesystem::path& p);
     void convert_to_seq_();
-    std::string nameStem_;
-    std::string seqNumStr_;
+    std::string stemPrefix_;
+    std::string stemSeqNum_;
+    std::string stemSuffix_;
     size_t determine_starting_index_() const;
 
     // encoding parameters


### PR DESCRIPTION
This enables parsing of image sequences with indices in locations other than the end of the file stem. The following  cases should now be handled:
- `test000.png` :: **Input:** test%03d.png, **Output:** test.mp4
- `000test.png` :: **Input:** %03dtest.png, **Output:** test.mp4
- `prefix000sufix.png` :: **Input:** prefix%03dsuffix.png, **Output:** prefixsuffix.mp4
- `000test000.png` :: **Exception:** Multiple numerical indices in stem: 000, 000. **Result:** Not added to queue.
- `test.png` :: **Exception:** Zero numerical indices in stem. **Result:** Not added to queue.